### PR TITLE
Simple protection against non-existing data dir

### DIFF
--- a/src/traits/helpers.php
+++ b/src/traits/helpers.php
@@ -322,7 +322,11 @@
       if ( $storableJSON === false ) throw new \Exception( 'Unable to encode the data array, 
         please provide a valid PHP associative array' );
       // Define the store path
-      $storePath = $this->storePath . 'data/' . $id . '.json';
+        $dataDirectory = $this->storePath . 'data/';
+        $storePath = $dataDirectory . $id . '.json';
+      if (!is_dir($dataDirectory)){
+          mkdir($dataDirectory);
+      }
       if ( ! file_put_contents( $storePath, $storableJSON ) ) {
         throw new \Exception( "Unable to write the object file! Please check if PHP has write permission." );
       }


### PR DESCRIPTION
In my case it threw "Unable to write the object file! Please check if PHP has write permission.", but the permissions were there. I figured it must be missing the data dir and I didn't find anything about creating one manually in the doc so... Not sure how it worked for other people... maybe it's my setup (PHP 7.2.19-0ubuntu0.18.04.2) but, these couple of lines helped.